### PR TITLE
Adapts for 9.3.0-4 images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,38 +7,38 @@ before_install:
   # Clone DualBootPatcher Repository
   - git clone --recursive https://github.com/yshalsager/DualBootPatcher -b master DualBootPatcher/
   # Pull docker images
-  - docker pull yshalsager/dualbootpatcher:9.3.0-2-base
-  - docker pull yshalsager/dualbootpatcher:9.3.0-2-android
-  - docker pull yshalsager/dualbootpatcher:9.3.0-2-linux
+  - docker pull yshalsager/dualbootpatcher:9.3.0-4-base
+  - docker pull yshalsager/dualbootpatcher:9.3.0-4-android
+  - docker pull yshalsager/dualbootpatcher:9.3.0-4-linux
 script:
   # Make work directories 
   - mkdir $HOME/.android
   - mkdir -p DualBootPatcher/builder/ && cd DualBootPatcher/
   # Build APK
   - |
-    docker run --rm -i -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) -v "$(pwd):/builder/DualBootPatcher:rw,z" -v "${HOME}/.android:/builder/.android:rw,z" yshalsager/dualbootpatcher:9.3.0-2-android bash << EOF
-    cd DualBootPatcher/builder && cmake .. -DMBP_BUILD_TARGET=android -DMBP_BUILD_TYPE=debug && make -j16 && rm -rf assets && cpack -G TXZ && make apk -j16
+    docker run --rm -i -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) -v "$(pwd):/builder/DualBootPatcher:rw,z" -v "${HOME}/.android:/builder/.android:rw,z" yshalsager/dualbootpatcher:9.3.0-4-android bash << EOF
+    cd DualBootPatcher/builder && cmake .. -DMBP_BUILD_TARGET=android -DMBP_BUILD_TYPE=debug && make -j16 && rm -rf assets && cpack && make apk -j16
     make android-system_armeabi-v7a -j16 && make -C data/devices -j16
     exit
     EOF
   - |
-    docker run --rm -i -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) -v "$(pwd):/builder/DualBootPatcher:rw,z" -v "${HOME}/.android:/builder/.android:rw,z" yshalsager/dualbootpatcher:9.3.0-2-linux bash << EOF
+    docker run --rm -i -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) -v "$(pwd):/builder/DualBootPatcher:rw,z" -v "${HOME}/.android:/builder/.android:rw,z" yshalsager/dualbootpatcher:9.3.0-4-linux bash << EOF
     # Build Utilities Zip
     cd ~/DualBootPatcher/builder && ./utilities/create.sh
     # Build Linux
-    cmake .. -DMBP_BUILD_TARGET=desktop -DMBP_PORTABLE=ON && make -j16 && cpack -G TXZ
+    cmake .. -DMBP_BUILD_TARGET=desktop -DMBP_PORTABLE=ON && make -j16 && cpack
     exit
     EOF
 after_success:
   - export TRAVIS_CURRENT_DATE=$(date +"%d%m%y-%Hh%Mm")
   # Check output & md5sum
-  - ls -l /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/Android_GUI/build/outputs/apk/Android_GUI-debug.apk
-  - md5sum /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/Android_GUI/build/outputs/apk/Android_GUI-debug.apk
+  - ls -l /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/Android_GUI/build/outputs/apk/debug/Android_GUI-debug.apk
+  - md5sum /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/Android_GUI/build/outputs/apk/debug/Android_GUI-debug.apk
   - ls -l /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/builder/utilities/DualBootUtilities-9.3.0.zip
   - md5sum /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/builder/utilities/DualBootUtilities-9.3.0.zip
   - ls -l /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/builder/DualBootPatcher-9.3.0-Linux.tar.xz
   - md5sum /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/builder/DualBootPatcher-9.3.0-Linux.tar.xz
   # Upload to transfer.sh
-  - cd /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/Android_GUI/build/outputs/apk/ &&  curl --upload-file ./Android_GUI-debug.apk https://transfer.sh/Android_GUI-debug-${TRAVIS_CURRENT_DATE}.apk
+  - cd /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/Android_GUI/build/outputs/apk/debug/ &&  curl --upload-file ./Android_GUI-debug.apk https://transfer.sh/Android_GUI-debug-${TRAVIS_CURRENT_DATE}.apk
   - cd /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/builder/utilities/ && curl --upload-file ./DualBootUtilities-9.3.0.zip https://transfer.sh/DualBootUtilities-9.3.0-${TRAVIS_CURRENT_DATE}.zip
   - cd /home/travis/build/yshalsager/DualBootPatcher/DualBootPatcher/builder/ && curl --upload-file ./DualBootPatcher-9.3.0-Linux.tar.xz https://transfer.sh/DualBootPatcher-9.3.0-${TRAVIS_CURRENT_DATE}-Linux.tar.xz


### PR DESCRIPTION
Changes for 9.3.0-4 docker images:

- remove flags from "cpack" command

- Debug Apk file is now in "DualBootPatcher/Android_GUI/build/outputs/apk/debug/"